### PR TITLE
implement useful document cleaners

### DIFF
--- a/cli/test/test_text2embeddings.py
+++ b/cli/test/test_text2embeddings.py
@@ -9,6 +9,7 @@ from click.testing import CliRunner
 from cpr_sdk.parser_models import ParserOutput
 
 from cli.text2embeddings import run_as_cli
+from src.config import BLOCKS_TO_FILTER
 
 
 def test_run_encoder_local(
@@ -45,7 +46,13 @@ def test_run_encoder_local(
             }
 
             for path in Path(output_dir).glob("*.json"):
-                assert ParserOutput.model_validate(json.loads(path.read_text()))
+                parser_output = ParserOutput.model_validate(
+                    json.loads(path.read_text())
+                )
+                text_blocks = parser_output.text_blocks
+                assert not any(
+                    text_block.type in BLOCKS_TO_FILTER for text_block in text_blocks
+                )
 
             for path in Path(output_dir).glob("*.npy"):
                 assert np.load(str(path)).shape[1] == 768

--- a/cli/text2embeddings.py
+++ b/cli/text2embeddings.py
@@ -21,7 +21,11 @@ from src.s3 import check_file_exists_in_s3, write_json_to_s3, save_ndarray_to_s3
 from src.pipeline import Pipeline
 from src.chunkers import IdentityChunker
 from src.serializers import BasicSerializer
-from src.document_cleaners import ChunkTypeFilter, RemoveShortTableCells
+from src.document_cleaners import (
+    ChunkTypeFilter,
+    RemoveShortTableCells,
+    RemoveRepeatedAdjacentChunks,
+)
 
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 DEFAULT_LOGGING = {
@@ -182,6 +186,7 @@ def run_embeddings_generation(
         document_cleaners=[
             ChunkTypeFilter(types_to_remove=config.BLOCKS_TO_FILTER),
             RemoveShortTableCells(min_chars=10, remove_all_numeric=True),
+            RemoveRepeatedAdjacentChunks(),
         ],
         serializer=BasicSerializer(),
         encoder=encoder,

--- a/cli/text2embeddings.py
+++ b/cli/text2embeddings.py
@@ -21,7 +21,7 @@ from src.s3 import check_file_exists_in_s3, write_json_to_s3, save_ndarray_to_s3
 from src.pipeline import Pipeline
 from src.chunkers import IdentityChunker
 from src.serializers import BasicSerializer
-from src.document_cleaners import ChunkTypeFilter
+from src.document_cleaners import ChunkTypeFilter, RemoveShortTableCells
 
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 DEFAULT_LOGGING = {
@@ -179,7 +179,10 @@ def run_embeddings_generation(
 
     pipeline = Pipeline(
         chunker=IdentityChunker(),
-        document_cleaners=[ChunkTypeFilter(types_to_remove=config.BLOCKS_TO_FILTER)],
+        document_cleaners=[
+            ChunkTypeFilter(types_to_remove=config.BLOCKS_TO_FILTER),
+            RemoveShortTableCells(min_chars=10, remove_all_numeric=True),
+        ],
         serializer=BasicSerializer(),
         encoder=encoder,
     )

--- a/cli/text2embeddings.py
+++ b/cli/text2embeddings.py
@@ -14,7 +14,6 @@ from src.languages import get_docs_of_supported_language
 from src.encoders import SBERTEncoder
 from src import config
 from src.utils import (
-    filter_on_block_type,
     get_files_to_process,
     get_Text2EmbeddingsInput_array,
 )
@@ -22,6 +21,7 @@ from src.s3 import check_file_exists_in_s3, write_json_to_s3, save_ndarray_to_s3
 from src.pipeline import Pipeline
 from src.chunkers import IdentityChunker
 from src.serializers import BasicSerializer
+from src.document_cleaners import ChunkTypeFilter
 
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
 DEFAULT_LOGGING = {
@@ -174,20 +174,12 @@ def run_embeddings_generation(
         },
     )
 
-    logger.info(
-        "Filtering unwanted text block types.",
-        extra={"props": {"BLOCKS_TO_FILTER": config.BLOCKS_TO_FILTER}},
-    )
-    tasks = filter_on_block_type(
-        inputs=tasks, remove_block_types=config.BLOCKS_TO_FILTER
-    )
-
     logger.info(f"Loading sentence-transformer model {config.SBERT_MODEL}")
     encoder = SBERTEncoder(config.SBERT_MODEL)
 
     pipeline = Pipeline(
         chunker=IdentityChunker(),
-        document_cleaners=[],
+        document_cleaners=[ChunkTypeFilter(types_to_remove=config.BLOCKS_TO_FILTER)],
         serializer=BasicSerializer(),
         encoder=encoder,
     )

--- a/src/document_cleaners.py
+++ b/src/document_cleaners.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Sequence
 from logging import getLogger
+import re
 
 from src.models import Chunk, ChunkType
 
@@ -50,3 +51,38 @@ class ChunkTypeFilter(BaseDocumentCleaner):
         return [
             chunk for chunk in chunks if chunk.chunk_type not in self.chunks_to_drop
         ]
+
+
+class RemoveShortTableCells(BaseDocumentCleaner):
+    """
+    Remove table cells under a certain number of characters, or are all numeric.
+
+    These aren't useful for encoding or search.
+    """
+
+    def __init__(self, min_chars: int = 10, remove_all_numeric: bool = True) -> None:
+        self.min_chars = min_chars
+        self.remove_all_numeric = remove_all_numeric
+
+    def __call__(self, chunks: Sequence[Chunk]) -> Sequence[Chunk]:
+        """Run table cell filtering."""
+        new_chunks: list[Chunk] = []
+
+        for chunk in chunks:
+            if chunk.chunk_type != ChunkType.TABLE_CELL:
+                new_chunks.append(chunk)
+                continue
+
+            if len(chunk.text) < self.min_chars:
+                continue
+
+            # Matches strings that are entirely numeric, optionally with a +/- sign,
+            # commas, spaces and decimal point
+            if self.remove_all_numeric and re.match(
+                r"^[+-]?[\d,\s]*\.?\d+$", chunk.text.strip()
+            ):
+                continue
+
+            new_chunks.append(chunk)
+
+        return new_chunks

--- a/src/document_cleaners.py
+++ b/src/document_cleaners.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Sequence
+from typing import Sequence, Optional
 from logging import getLogger
 import re
 
@@ -84,5 +84,64 @@ class RemoveShortTableCells(BaseDocumentCleaner):
                 continue
 
             new_chunks.append(chunk)
+
+        return new_chunks
+
+
+class RemoveRepeatedAdjacentChunks(BaseDocumentCleaner):
+    """
+    Remove chunks of the same type that are repeated, keeping the first.
+
+    This is useful for headers, footers and headings that may be repeated once per page
+    in a document.
+    """
+
+    def __init__(
+        self,
+        chunk_types=[
+            ChunkType.SECTION_HEADING,
+            ChunkType.TITLE,
+            ChunkType.PAGE_HEADER,
+            ChunkType.PAGE_FOOTER,
+            ChunkType.FOOTNOTE,
+        ],
+        ignore_case: bool = True,
+    ) -> None:
+        """
+        Args:
+
+        :param chunk_types: list of chunk types to check for repeating
+        :param ignore_case: whether filtering ignores case. Defaults to True
+        """
+        self.chunk_types = chunk_types
+        self.ignore_case = ignore_case
+
+    def __call__(self, chunks: Sequence[Chunk]) -> Sequence[Chunk]:
+        """Run repeated adjacent chunk filtering."""
+        new_chunks: list[Chunk] = []
+        current_chunk_of_type: dict[ChunkType, Optional[str]] = {
+            chunk_type: None for chunk_type in self.chunk_types
+        }
+
+        for chunk in chunks:
+            if chunk.chunk_type not in self.chunk_types:
+                new_chunks.append(chunk)
+                continue
+
+            current_text = current_chunk_of_type[chunk.chunk_type]
+            chunk_text = chunk.text.lower() if self.ignore_case else chunk.text
+
+            match current_text:
+                case None:
+                    # First time seeing this chunk type
+                    current_chunk_of_type[chunk.chunk_type] = chunk_text
+                    new_chunks.append(chunk)
+                case matched_text if matched_text != chunk_text:
+                    # Different text than previous chunk of this type
+                    current_chunk_of_type[chunk.chunk_type] = chunk_text
+                    new_chunks.append(chunk)
+                case _:
+                    # Same text as previous chunk of this type, skip it
+                    continue
 
         return new_chunks

--- a/src/document_cleaners.py
+++ b/src/document_cleaners.py
@@ -44,12 +44,12 @@ class ChunkTypeFilter(BaseDocumentCleaner):
                 )
                 types_to_remove.remove(_type)
 
-        self.chunks_to_drop = types_to_remove
+        self.types_to_remove = types_to_remove
 
     def __call__(self, chunks: Sequence[Chunk]) -> Sequence[Chunk]:
         """Run chunk type filtering."""
         return [
-            chunk for chunk in chunks if chunk.chunk_type not in self.chunks_to_drop
+            chunk for chunk in chunks if chunk.chunk_type not in self.types_to_remove
         ]
 
 

--- a/src/test/test_document_cleaners.py
+++ b/src/test/test_document_cleaners.py
@@ -1,0 +1,91 @@
+from src.models import Chunk, ChunkType
+from src.document_cleaners import RemoveShortTableCells
+
+
+def test_remove_short_table_cells_drop_numeric():
+    """Test filtering of short and numeric table cells."""
+    cleaner = RemoveShortTableCells(min_chars=5, remove_all_numeric=True)
+    chunks = [
+        Chunk(
+            text="short",
+            chunk_type=ChunkType.TABLE_CELL,
+            bounding_boxes=None,
+            pages=None,
+        ),
+        Chunk(
+            text="this is long enough",
+            chunk_type=ChunkType.TABLE_CELL,
+            bounding_boxes=None,
+            pages=None,
+        ),
+        Chunk(
+            text="123.45",
+            chunk_type=ChunkType.TABLE_CELL,
+            bounding_boxes=None,
+            pages=None,
+        ),
+        Chunk(
+            text="1,234.56",
+            chunk_type=ChunkType.TABLE_CELL,
+            bounding_boxes=None,
+            pages=None,
+        ),
+        Chunk(
+            text="-123.45",
+            chunk_type=ChunkType.TABLE_CELL,
+            bounding_boxes=None,
+            pages=None,
+        ),
+        Chunk(
+            text="not a table cell",
+            chunk_type=ChunkType.TEXT,
+            bounding_boxes=None,
+            pages=None,
+        ),
+        Chunk(
+            text="12345 with text",
+            chunk_type=ChunkType.TABLE_CELL,
+            bounding_boxes=None,
+            pages=None,
+        ),
+    ]
+
+    result = cleaner(chunks)
+
+    assert len(result) == 4
+    assert result[0].text == "short"
+    assert result[1].text == "this is long enough"
+    assert result[2].text == "not a table cell"
+    assert result[3].text == "12345 with text"
+
+
+def test_remove_short_table_cells_keep_numeric():
+    """Test keeping numeric cells when remove_all_numeric is False."""
+    cleaner = RemoveShortTableCells(min_chars=6, remove_all_numeric=False)
+
+    chunks = [
+        Chunk(
+            text="short",
+            chunk_type=ChunkType.TABLE_CELL,
+            bounding_boxes=None,
+            pages=None,
+        ),
+        Chunk(
+            text="123.45",
+            chunk_type=ChunkType.TABLE_CELL,
+            bounding_boxes=None,
+            pages=None,
+        ),
+        Chunk(
+            text="1,234.56",
+            chunk_type=ChunkType.TABLE_CELL,
+            bounding_boxes=None,
+            pages=None,
+        ),
+    ]
+
+    result = cleaner(chunks)
+
+    assert len(result) == 2
+    assert result[0].text == "123.45"
+    assert result[1].text == "1,234.56"

--- a/src/test/test_utils.py
+++ b/src/test/test_utils.py
@@ -9,37 +9,9 @@ from src.encoders import SBERTEncoder
 from src.utils import (
     encode_parser_output,
     filter_blocks,
-    filter_on_block_type,
     get_ids_with_suffix,
     replace_text_blocks,
 )
-
-
-def test_filter_on_block_type(test_parser_output_array):
-    """Tests that the filter_on_block_type function removes the correct text blocks."""
-
-    filtered_inputs = filter_on_block_type(
-        inputs=test_parser_output_array, remove_block_types=["Text", "Figure"]
-    )
-
-    assert filtered_inputs[0].html_data is not None
-    assert len(filtered_inputs[0].html_data.text_blocks) == 2
-
-    assert filtered_inputs[0].html_data.text_blocks[0].type == "Table"
-    assert filtered_inputs[0].html_data.text_blocks[0].text == ["test_text"]
-
-    assert filtered_inputs[0].html_data.text_blocks[1].type == "sectionHeading"
-    assert filtered_inputs[0].html_data.text_blocks[1].text == ["test_text"]
-
-    # Assert that we can filter on IndexerInputs that don't have valid text
-    assert filtered_inputs[1].html_data is not None
-    assert len(filtered_inputs[1].html_data.text_blocks) == 2
-
-    assert filtered_inputs[1].html_data.text_blocks[0].type == "Table"
-    assert filtered_inputs[1].html_data.text_blocks[0].text == ["test_text"]
-
-    assert filtered_inputs[1].html_data.text_blocks[1].type == "sectionHeading"
-    assert filtered_inputs[1].html_data.text_blocks[1].text == ["test_text"]
 
 
 def test_has_valid_text_override(test_parser_output_array: Sequence[ParserOutput]):

--- a/src/utils.py
+++ b/src/utils.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import List, Optional, Sequence, Set, Tuple, Union
 
 import numpy as np
-from cpr_sdk.parser_models import BlockType, ParserOutput, TextBlock
+from cpr_sdk.parser_models import ParserOutput, TextBlock
 
 from src import config
 from src.encoders import BaseEncoder
@@ -48,36 +48,6 @@ def filter_blocks(
                 },
             )
     return filtered_blocks
-
-
-def filter_on_block_type(
-    inputs: Sequence[ParserOutput], remove_block_types: List[str]
-) -> Sequence[ParserOutput]:
-    """
-    Filter a sequence of ParserOutputs.
-
-    Remove the text blocks that are of the types declared in the remove block types
-    array.
-    """
-    for _filter in remove_block_types:
-        try:
-            BlockType(_filter)
-        except NameError:
-            logger.warning(
-                f"Blocks to filter should be of a known block type, removing {_filter} "
-                f"from the list. "
-            )
-            remove_block_types.remove(_filter)
-
-    return [
-        replace_text_blocks(
-            block=_input,
-            new_text_blocks=filter_blocks(
-                parser_output=_input, remove_block_types=remove_block_types
-            ),
-        )
-        for _input in inputs
-    ]
 
 
 def get_ids_with_suffix(files: Sequence[str], suffix: str) -> Set[str]:


### PR DESCRIPTION
Implements some document cleaners which were worth putting together before chunking, as they'll make that step easier.

- Filtering out short table cells – adapted from [Matyas's text quality fix](https://www.notion.so/climatepolicyradar/Brief-FIX-004-NA-THAT-1829109609a480d1a565ff7e8b92f250) with some minor changes to explicitly ignore numeric cells (This is not the right end-state solution, but works for now).
- Filtering out repeated titles, headings, headers and footers – this is a need I identified from building the document viewer
- Replacing filtering of `Table` and `Figure` types that already existed with another `DocumentCleaner` (although neither of these do anything with the current parser I think!).
  -  Added a few lines to the test to check for this behaviour explicitly.

None of these are _required_ for all pipelines, but I think they're all required for encoding and search. We can swap them out later as needed :)
