### PR TITLE
pipeline components all input and output list of chunks

### DIFF
--- a/src/chunkers.py
+++ b/src/chunkers.py
@@ -34,6 +34,7 @@ class IdentityChunker(BaseChunker):
 
         chunks = [
             Chunk(
+                id=text_block.text_block_id,
                 text=text_block.to_string(),
                 chunk_type=ChunkType(text_block.type),
                 bounding_boxes=[text_block.coords]

--- a/src/chunkers.py
+++ b/src/chunkers.py
@@ -1,25 +1,11 @@
 """Classes for chunking documents."""
 
 from typing import Sequence
-from abc import ABC, abstractmethod
 
-from src.models import Chunk
-
-
-class BaseChunker(ABC):
-    """Base class for performing chunking on a document."""
-
-    @abstractmethod
-    def __call__(
-        self,
-        chunks: Sequence[Chunk],
-    ) -> Sequence[Chunk]:
-        """Run chunker."""
-
-        raise NotImplementedError
+from src.models import Chunk, PipelineComponent
 
 
-class IdentityChunker(BaseChunker):
+class IdentityChunker(PipelineComponent):
     """Returns the text blocks converted to chunks, with no attempts at changing them."""
 
     def __call__(
@@ -31,7 +17,7 @@ class IdentityChunker(BaseChunker):
         return list(chunks)
 
 
-# class GreedyStructureAwareChunker(BaseChunker):
+# class GreedyStructureAwareChunker(PipelineComponent):
 #     """
 #     Chunker which makes use of the structure of the document.
 

--- a/src/chunkers.py
+++ b/src/chunkers.py
@@ -3,8 +3,7 @@
 from typing import Sequence
 from abc import ABC, abstractmethod
 
-from cpr_sdk.parser_models import ParserOutput, PDFTextBlock
-from src.models import ChunkType, Chunk
+from src.models import Chunk
 
 
 class BaseChunker(ABC):
@@ -13,7 +12,7 @@ class BaseChunker(ABC):
     @abstractmethod
     def __call__(
         self,
-        document: ParserOutput,
+        chunks: Sequence[Chunk],
     ) -> Sequence[Chunk]:
         """Run chunker."""
 
@@ -25,26 +24,20 @@ class IdentityChunker(BaseChunker):
 
     def __call__(
         self,
-        document: ParserOutput,
+        chunks: Sequence[Chunk],
     ) -> list[Chunk]:
         """Run chunker."""
 
-        if not document.text_blocks:
-            return []
+        return list(chunks)
 
-        chunks = [
-            Chunk(
-                id=text_block.text_block_id,
-                text=text_block.to_string(),
-                chunk_type=ChunkType(text_block.type),
-                bounding_boxes=[text_block.coords]
-                if isinstance(text_block, PDFTextBlock) and text_block.coords
-                else None,
-                pages=[text_block.page_number]
-                if isinstance(text_block, PDFTextBlock)
-                else None,
-            )
-            for text_block in document.text_blocks
-        ]
 
-        return chunks
+# class GreedyStructureAwareChunker(BaseChunker):
+#     """
+#     Chunker which makes use of the structure of the document.
+
+#     All headings and subheadings are separate chunks. All consecutive non-heading chunks
+#     are merged into single text blocks with the respective type.
+#     """
+
+#     def __call__(self, document: Sequence[Chunk]) -> Sequence[Chunk]:
+#         """Run chunking."""

--- a/src/document_cleaners.py
+++ b/src/document_cleaners.py
@@ -1,23 +1,13 @@
-from abc import ABC, abstractmethod
 from typing import Sequence, Optional
 from logging import getLogger
 import re
 
-from src.models import Chunk, ChunkType
+from src.models import Chunk, ChunkType, PipelineComponent
 
 logger = getLogger(__name__)
 
 
-class BaseDocumentCleaner(ABC):
-    """Base class for perfoming cleaning on a sequence of chunks"""
-
-    @abstractmethod
-    def __call__(self, chunks: Sequence[Chunk]) -> Sequence[Chunk]:
-        """Run document cleaning"""
-        raise NotImplementedError()
-
-
-class IdentityDocumentCleaner(BaseDocumentCleaner):
+class IdentityDocumentCleaner(PipelineComponent):
     """Returns all the chunks. Useful for testing."""
 
     def __call__(self, chunks: Sequence[Chunk]) -> list[Chunk]:
@@ -25,7 +15,7 @@ class IdentityDocumentCleaner(BaseDocumentCleaner):
         return list(chunks)
 
 
-class ChunkTypeFilter(BaseDocumentCleaner):
+class ChunkTypeFilter(PipelineComponent):
     """Filter out chunks of specified types."""
 
     def __init__(self, types_to_remove: list[str]) -> None:
@@ -53,7 +43,7 @@ class ChunkTypeFilter(BaseDocumentCleaner):
         ]
 
 
-class RemoveShortTableCells(BaseDocumentCleaner):
+class RemoveShortTableCells(PipelineComponent):
     """
     Remove table cells under a certain number of characters, or are all numeric.
 
@@ -88,7 +78,7 @@ class RemoveShortTableCells(BaseDocumentCleaner):
         return new_chunks
 
 
-class RemoveRepeatedAdjacentChunks(BaseDocumentCleaner):
+class RemoveRepeatedAdjacentChunks(PipelineComponent):
     """
     Remove chunks of the same type that are repeated, keeping the first.
 
@@ -147,7 +137,7 @@ class RemoveRepeatedAdjacentChunks(BaseDocumentCleaner):
         return new_chunks
 
 
-class AddHeadings(BaseDocumentCleaner):
+class AddHeadings(PipelineComponent):
     """
     Add headings to chunks.
 

--- a/src/models.py
+++ b/src/models.py
@@ -26,6 +26,7 @@ class ChunkType(str, Enum):
 class Chunk(BaseModel):
     """A unit part of a document."""
 
+    id: str
     text: str
     chunk_type: ChunkType
     # TODO: do we want multiple headings here? this is what docling does.

--- a/src/models.py
+++ b/src/models.py
@@ -35,6 +35,8 @@ class Chunk(BaseModel):
     # TODO: is this true according to the backend or frontend?
     bounding_boxes: Optional[list[list[tuple[float, float]]]]
     pages: Optional[list[int]]
+    tokens: Optional[list[str]] = None
+    serialized_text: Optional[str] = None
 
     def _verify_bbox_and_pages(self) -> None:
         if self.bounding_boxes is not None and self.pages is not None:

--- a/src/models.py
+++ b/src/models.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from abc import ABC, abstractmethod
 
 from enum import Enum
 from pydantic import BaseModel
@@ -41,3 +42,18 @@ class Chunk(BaseModel):
     def _verify_bbox_and_pages(self) -> None:
         if self.bounding_boxes is not None and self.pages is not None:
             assert len(self.bounding_boxes) == len(self.pages)
+
+
+class PipelineComponent(ABC):
+    """
+    A component of the pipeline.
+
+    When called, takes a list of chunks as input and returns a list of chunks. This
+    should be used as the base class for every pipeline component except for the
+    encoder.
+    """
+
+    @abstractmethod
+    def __call__(self, chunks: list[Chunk]) -> list[Chunk]:
+        """Base class for any pipeline component."""
+        raise NotImplementedError

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -4,10 +4,7 @@ from logging import getLogger
 import numpy as np
 from cpr_sdk.parser_models import ParserOutput, PDFTextBlock
 
-from src.models import Chunk, ChunkType
-from src.chunkers import BaseChunker
-from src.document_cleaners import BaseDocumentCleaner
-from src.serializers import BaseSerializer
+from src.models import Chunk, ChunkType, PipelineComponent
 from src.encoders import BaseEncoder
 
 logger = getLogger(__name__)
@@ -41,9 +38,9 @@ class Pipeline:
 
     def __init__(
         self,
-        chunker: BaseChunker,
-        document_cleaners: Sequence[BaseDocumentCleaner],
-        serializer: BaseSerializer,
+        chunker: PipelineComponent,
+        document_cleaners: Sequence[PipelineComponent],
+        serializer: PipelineComponent,
         encoder: Optional[BaseEncoder] = None,
     ) -> None:
         self.chunker = chunker
@@ -81,7 +78,7 @@ class Pipeline:
         if chunks == []:
             return self.get_empty_response()
 
-        serialized_chunks: list[Chunk] = [self.serializer(chunk) for chunk in chunks]
+        serialized_chunks: list[Chunk] = self.serializer(chunks)
         serialized_text = [
             chunk.serialized_text or "NONE" for chunk in serialized_chunks
         ]

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -1,13 +1,36 @@
 from typing import Optional, Sequence
 
 import numpy as np
-from cpr_sdk.parser_models import ParserOutput
+from cpr_sdk.parser_models import ParserOutput, PDFTextBlock
 
-from src.models import Chunk
+from src.models import Chunk, ChunkType
 from src.chunkers import BaseChunker
 from src.document_cleaners import BaseDocumentCleaner
 from src.serializers import BaseSerializer
 from src.encoders import BaseEncoder
+
+
+def parser_output_to_chunks(parser_output: ParserOutput) -> list[Chunk]:
+    """Convert a parser output to a list of chunks."""
+    if not parser_output.text_blocks:
+        return []
+
+    chunks = [
+        Chunk(
+            id=text_block.text_block_id,
+            text=text_block.to_string(),
+            chunk_type=ChunkType(text_block.type),
+            bounding_boxes=[text_block.coords]
+            if isinstance(text_block, PDFTextBlock) and text_block.coords
+            else None,
+            pages=[text_block.page_number]
+            if isinstance(text_block, PDFTextBlock)
+            else None,
+        )
+        for text_block in parser_output.text_blocks
+    ]
+
+    return chunks
 
 
 class Pipeline:
@@ -24,35 +47,8 @@ class Pipeline:
         self.document_cleaners = document_cleaners
         self.serializer = serializer
         self.encoder = encoder
-        # self._validate_pipeline()
 
         self.pipeline_return_type = list[str] if self.encoder is None else np.ndarray
-
-    def _validate_pipeline(self) -> None:
-        """
-        Check that the pipeline components are valid.
-
-        Raises a ValueError if not.
-        """
-
-        component_type_map = {
-            "chunker": BaseChunker,
-            "document_cleaners": Sequence[BaseDocumentCleaner],
-            "serializer": BaseSerializer,
-            "encoder": Optional[BaseEncoder],
-        }
-
-        incorrect_typed_components = [
-            k for k, v in component_type_map.items() if not isinstance(k, v)
-        ]
-
-        if incorrect_typed_components:
-            incorrect_typed_components_msg = ",".join(
-                f"{k} ({component_type_map[k]})" for k in incorrect_typed_components
-            )
-            raise ValueError(
-                f"The following components have incorrect types: {incorrect_typed_components_msg}"
-            )
 
     def get_empty_response(self) -> list[str] | np.ndarray:
         """Return an empty list or array depending on the pipeline configuration."""
@@ -71,7 +67,9 @@ class Pipeline:
                 "This pipeline contains an encoder but no batch size was set. Please set a batch size."
             )
 
-        chunks: Sequence[Chunk] = self.chunker(document)
+        chunks = parser_output_to_chunks(document)
+
+        chunks: Sequence[Chunk] = self.chunker(chunks)
 
         for cleaner in self.document_cleaners:
             chunks = cleaner(chunks)

--- a/src/serializers.py
+++ b/src/serializers.py
@@ -10,10 +10,14 @@ class BasicSerializer(PipelineComponent):
     Returns the chunk with text added in the `serialized_text` field.
     """
 
-    def __call__(self, chunk: Chunk) -> Chunk:
+    def __call__(self, chunks: list) -> list[Chunk]:
         """Run serialization."""
-        chunk.serialized_text = chunk.text
-        return chunk
+        new_chunks = list(chunks)
+
+        for chunk in new_chunks:
+            chunk.serialized_text = chunk.text
+
+        return new_chunks
 
 
 class HeadingAwareSerializer(PipelineComponent):
@@ -27,13 +31,16 @@ class HeadingAwareSerializer(PipelineComponent):
     def __init__(self, template: Optional[str]) -> None:
         self.template: str = template or "{text} – {heading}"
 
-    def __call__(self, chunk: Chunk) -> Chunk:
+    def __call__(self, chunks: list[Chunk]) -> list[Chunk]:
         """Run serialization."""
 
-        chunk.serialized_text = (
-            self.template.format(text=chunk.text, heading=chunk.heading)
-            if chunk.heading
-            else chunk.text
-        )
+        new_chunks = list(chunks)
 
-        return chunk
+        for chunk in new_chunks:
+            chunk.serialized_text = (
+                self.template.format(text=chunk.text, heading=chunk.heading)
+                if chunk.heading
+                else chunk.text
+            )
+
+        return chunks

--- a/src/serializers.py
+++ b/src/serializers.py
@@ -8,17 +8,22 @@ class BaseSerializer(ABC):
     """Base class for serialising chunks into strings"""
 
     @abstractmethod
-    def __call__(self, chunk: Chunk) -> str:
+    def __call__(self, chunk: Chunk) -> Chunk:
         """Run serialization."""
         raise NotImplementedError
 
 
 class BasicSerializer(BaseSerializer):
-    """The most basic serializer. Returns the text of the chunk."""
+    """
+    The most basic serializer.
 
-    def __call__(self, chunk: Chunk) -> str:
+    Returns the chunk with text added in the `serialized_text` field.
+    """
+
+    def __call__(self, chunk: Chunk) -> Chunk:
         """Run serialization."""
-        return chunk.text
+        chunk.serialized_text = chunk.text
+        return chunk
 
 
 class HeadingAwareSerializer(BaseSerializer):
@@ -32,9 +37,13 @@ class HeadingAwareSerializer(BaseSerializer):
     def __init__(self, template: Optional[str]) -> None:
         self.template: str = template or "{text} – {heading}"
 
-    def __call__(self, chunk: Chunk) -> str:
+    def __call__(self, chunk: Chunk) -> Chunk:
         """Run serialization."""
-        if chunk.heading is None:
-            return chunk.text
 
-        return self.template.format(text=chunk.text, heading=chunk.heading)
+        chunk.serialized_text = (
+            self.template.format(text=chunk.text, heading=chunk.heading)
+            if chunk.heading
+            else chunk.text
+        )
+
+        return chunk

--- a/src/serializers.py
+++ b/src/serializers.py
@@ -1,19 +1,9 @@
-from abc import ABC, abstractmethod
 from typing import Optional
 
-from src.models import Chunk
+from src.models import Chunk, PipelineComponent
 
 
-class BaseSerializer(ABC):
-    """Base class for serialising chunks into strings"""
-
-    @abstractmethod
-    def __call__(self, chunk: Chunk) -> Chunk:
-        """Run serialization."""
-        raise NotImplementedError
-
-
-class BasicSerializer(BaseSerializer):
+class BasicSerializer(PipelineComponent):
     """
     The most basic serializer.
 
@@ -26,7 +16,7 @@ class BasicSerializer(BaseSerializer):
         return chunk
 
 
-class HeadingAwareSerializer(BaseSerializer):
+class HeadingAwareSerializer(PipelineComponent):
     """
     Returns the text of the chunk and its heading according to a template.
 


### PR DESCRIPTION
Everything except the encoder is now a `PipelineComponent`, which takes `list[Chunk]` as input and output. This means we can put together a pipeline with any order of components (thanks @harrisonpim for the idea!).

Also includes an extra `DocumentCleaner` which adds headings to chunks and its tests.

Future work that will likely happen soon after this in other PRs:
- Rename `DocumentCleaner` (confusing! maybe something like `ChunkTransformer`)
- Make the roles of each component clearer. I think they should still be separate, but it'd be helpful to make their different roles really clear for namespacing reasons.
- Put together a more flexible pipeline implementation, so components can be fed in any order
