### PR TITLE
Feature/sci 283 second batch of chunk processors

### DIFF
--- a/cli/dev_pipeline.py
+++ b/cli/dev_pipeline.py
@@ -26,9 +26,6 @@ def run_on_document(document_path: Path):
             chunk_processors.ChunkTypeFilter(types_to_remove=["pageNumber"]),
             chunk_processors.RemoveFalseCheckboxes(),
             chunk_processors.CombineTextChunksIntoList(),
-            chunk_processors.CombineSuccessiveSameTypeChunks(
-                chunk_types=["text"], text_separator="\n"
-            ),
             chunkers.IdentityChunker(),
             serializers.BasicSerializer(),
         ]

--- a/cli/dev_pipeline.py
+++ b/cli/dev_pipeline.py
@@ -23,9 +23,8 @@ def run_on_document(document_path: Path):
             chunk_processors.RemoveShortTableCells(),
             chunk_processors.RemoveRepeatedAdjacentChunks(),
             chunk_processors.AddHeadings(),
-            chunk_processors.ChunkTypeFilter(
-                types_to_remove=["pageHeader", "pageFooter", "pageNumber"]
-            ),
+            chunk_processors.ChunkTypeFilter(types_to_remove=["pageNumber"]),
+            chunk_processors.RemoveFalseCheckboxes(),
             chunkers.IdentityChunker(),
             serializers.BasicSerializer(),
         ]

--- a/cli/text2embeddings.py
+++ b/cli/text2embeddings.py
@@ -25,6 +25,7 @@ from src.chunk_processors import (
     ChunkTypeFilter,
     RemoveShortTableCells,
     RemoveRepeatedAdjacentChunks,
+    RemoveFalseCheckboxes,
 )
 
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
@@ -188,6 +189,7 @@ def run_embeddings_generation(
             RemoveShortTableCells(min_chars=10, remove_all_numeric=True),
             RemoveRepeatedAdjacentChunks(),
             BasicSerializer(),
+            RemoveFalseCheckboxes(),
         ],
         encoder=encoder,
     )

--- a/cli/text2embeddings.py
+++ b/cli/text2embeddings.py
@@ -186,7 +186,7 @@ def run_embeddings_generation(
         components=[
             IdentityChunker(),
             ChunkTypeFilter(types_to_remove=config.BLOCKS_TO_FILTER),
-            RemoveShortTableCells(min_chars=10, remove_all_numeric=True),
+            RemoveShortTableCells(min_chars=0, remove_all_numeric=True),
             RemoveRepeatedAdjacentChunks(),
             BasicSerializer(),
             RemoveFalseCheckboxes(),

--- a/src/chunk_processors.py
+++ b/src/chunk_processors.py
@@ -281,7 +281,7 @@ class CombineSuccessiveSameTypeChunks(PipelineComponent):
             # If it's the same type, merge the chunks.
             if chunk.chunk_type == current_chunk.chunk_type:
                 current_chunk = current_chunk.merge(
-                    chunk, text_separator=self.text_separator
+                    [chunk], text_separator=self.text_separator
                 )
             # Otherwise, add the current chunk and set a new one.
             else:
@@ -329,7 +329,7 @@ class CombineTextChunksIntoList(PipelineComponent):
                 if current_list_chunk:
                     # Merge with existing list chunk
                     current_list_chunk = current_list_chunk.merge(
-                        chunk, text_separator=self.text_separator
+                        [chunk], text_separator=self.text_separator
                     )
                 else:
                     # Create new list chunk

--- a/src/chunk_processors.py
+++ b/src/chunk_processors.py
@@ -58,7 +58,7 @@ class RemoveShortTableCells(PipelineComponent):
     These aren't useful for encoding or search.
     """
 
-    def __init__(self, min_chars: int = 10, remove_all_numeric: bool = True) -> None:
+    def __init__(self, min_chars: int = 0, remove_all_numeric: bool = True) -> None:
         self.min_chars = min_chars
         self.remove_all_numeric = remove_all_numeric
 

--- a/src/chunk_processors.py
+++ b/src/chunk_processors.py
@@ -24,7 +24,7 @@ def filter_and_warn_for_unknown_types(types: list[str]) -> list[str]:
 
     types_to_remove: list[str] = []
 
-    for _type in types:
+    for _type in set(types):
         try:
             BlockType(_type)
         except NameError:
@@ -213,8 +213,6 @@ class RemoveRegexPattern(PipelineComponent):
 
     def __call__(self, chunks: list[Chunk]) -> list[Chunk]:
         """Run regex pattern removal."""
-        if not hasattr(self, "pattern"):
-            raise ValueError("No pattern was set. Please set a pattern in __init__.")
 
         new_chunks: list[Chunk] = []
 
@@ -248,10 +246,15 @@ class RemoveFalseCheckboxes(RemoveRegexPattern):
 
 
 class CombineSuccessiveSameTypeChunks(PipelineComponent):
-    """Combines successive chunks of the same type in a sequence of chunks."""
+    """
+    Combines successive chunks of the same type in a sequence of chunks.
 
-    def __init__(self, chunk_types: list[str], text_separator="\n") -> None:
-        self.chunk_types = filter_and_warn_for_unknown_types(chunk_types)
+    :param chunk_types_to_combine: chunk types to be considered for combining. Only
+    chunks of the same type will be combined.
+    """
+
+    def __init__(self, chunk_types_to_combine: list[str], text_separator="\n") -> None:
+        self.chunk_types = filter_and_warn_for_unknown_types(chunk_types_to_combine)
         self.text_separator = text_separator
 
     def __call__(self, chunks: list[Chunk]) -> list[Chunk]:

--- a/src/chunk_processors.py
+++ b/src/chunk_processors.py
@@ -219,3 +219,14 @@ class RemoveRegexPattern(PipelineComponent):
                 new_chunks.append(new_chunk)
 
         return new_chunks
+
+
+class RemoveFalseCheckboxes(RemoveRegexPattern):
+    """
+    Remove false checkboxes from the Azure output.
+
+    These are :selected: and :unselected: patterns.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(pattern=r"\s?:(?:un)?selected:\s?", replace_with=" ")

--- a/src/models.py
+++ b/src/models.py
@@ -1,9 +1,12 @@
 from typing import Optional
 from abc import ABC, abstractmethod
+import logging
 
 from pydantic import BaseModel
 
 from cpr_sdk.parser_models import BlockType
+
+logger = logging.getLogger(__name__)
 
 
 class Chunk(BaseModel):
@@ -24,6 +27,60 @@ class Chunk(BaseModel):
     def _verify_bbox_and_pages(self) -> None:
         if self.bounding_boxes is not None and self.pages is not None:
             assert len(self.bounding_boxes) == len(self.pages)
+
+    def merge(self, other: "Chunk", text_separator: str = " ") -> "Chunk":
+        """
+        Merge the chunk with another chunk.
+
+        The ID and chunk type are taken from the first chunk.
+        """
+
+        nullable_properties_with_issue = [
+            property_name
+            for property_name in ["bounding_boxes", "pages"]
+            if (getattr(self, property_name) is None)
+            != (getattr(other, property_name) is None)
+        ]
+
+        optional_properties_with_issue = [
+            property_name
+            for property_name in ["heading", "tokens", "serialized_text"]
+            if (getattr(self, property_name) is None)
+            or (getattr(other, property_name) is None)
+        ]
+
+        if nullable_properties_with_issue:
+            raise ValueError(
+                f"Properties {nullable_properties_with_issue} of chunks being merged must be either both None or both not None."
+            )
+
+        if optional_properties_with_issue:
+            logger.warning(
+                f"Properties {optional_properties_with_issue} of chunks being merged have been set for one or more chunks. These properties will be lost in the merge."
+            )
+
+        combined_bounding_boxes = (
+            self.bounding_boxes + other.bounding_boxes
+            if (self.bounding_boxes is not None) and (other.bounding_boxes is not None)
+            else None
+        )
+        combined_pages = (
+            self.pages + other.pages
+            if (self.pages is not None) and (other.pages is not None)
+            else None
+        )
+
+        return Chunk(
+            # TODO: can we better handle IDs when merging chunks?
+            id=self.id,
+            text=text_separator.join([self.text, other.text]),
+            chunk_type=self.chunk_type,
+            bounding_boxes=combined_bounding_boxes,
+            pages=combined_pages,
+            heading=None,
+            tokens=None,
+            serialized_text=None,
+        )
 
 
 class PipelineComponent(ABC):

--- a/src/models.py
+++ b/src/models.py
@@ -28,52 +28,84 @@ class Chunk(BaseModel):
         if self.bounding_boxes is not None and self.pages is not None:
             assert len(self.bounding_boxes) == len(self.pages)
 
-    def merge(self, other: "Chunk", text_separator: str = " ") -> "Chunk":
+    def _check_incompatible_properties(self, others: list["Chunk"]) -> list[str]:
+        """Check if nullable properties are consistent across chunks to be merged."""
+        nullable_properties = ["bounding_boxes", "pages"]
+        properties_with_issues = []
+
+        for prop in nullable_properties:
+            self_is_none = getattr(self, prop) is None
+            if any((getattr(chunk, prop) is None) != self_is_none for chunk in others):
+                properties_with_issues.append(prop)
+
+        return properties_with_issues
+
+    def _check_optional_properties(self, others: list["Chunk"]) -> list[str]:
+        """Check which optional properties will be lost in merge."""
+        optional_properties = ["heading", "tokens", "serialized_text"]
+        properties_with_issues = []
+
+        for prop in optional_properties:
+            if getattr(self, prop) is not None or any(
+                getattr(chunk, prop) is not None for chunk in others
+            ):
+                properties_with_issues.append(prop)
+
+        return properties_with_issues
+
+    def merge(self, others: list["Chunk"], text_separator: str = " ") -> "Chunk":
         """
-        Merge the chunk with another chunk.
+        Merge multiple chunks into a single chunk.
 
         The ID and chunk type are taken from the first chunk.
         """
 
-        nullable_properties_with_issue = [
-            property_name
-            for property_name in ["bounding_boxes", "pages"]
-            if (getattr(self, property_name) is None)
-            != (getattr(other, property_name) is None)
-        ]
+        if not others:
+            return self
 
-        optional_properties_with_issue = [
-            property_name
-            for property_name in ["heading", "tokens", "serialized_text"]
-            if (getattr(self, property_name) is None)
-            or (getattr(other, property_name) is None)
-        ]
+        if not isinstance(others, list) or not all(
+            isinstance(chunk, Chunk) for chunk in others
+        ):
+            raise ValueError("Chunks to be merged must be a list of Chunk objects.")
 
-        if nullable_properties_with_issue:
+        incompatible_properties = self._check_incompatible_properties(others)
+        if incompatible_properties:
             raise ValueError(
-                f"Properties {nullable_properties_with_issue} of chunks being merged must be either both None or both not None."
+                f"Properties {incompatible_properties} of chunks being merged must be either all None or all not None."
             )
 
+        optional_properties_with_issue = self._check_optional_properties(others)
         if optional_properties_with_issue:
             logger.warning(
                 f"Properties {optional_properties_with_issue} of chunks being merged have been set for one or more chunks. These properties will be lost in the merge."
             )
 
-        combined_bounding_boxes = (
-            self.bounding_boxes + other.bounding_boxes
-            if (self.bounding_boxes is not None) and (other.bounding_boxes is not None)
-            else None
-        )
-        combined_pages = (
-            self.pages + other.pages
-            if (self.pages is not None) and (other.pages is not None)
-            else None
-        )
+        all_chunks = [self] + others
+        all_texts = [chunk.text for chunk in all_chunks]
+        if self.bounding_boxes is None:
+            combined_bounding_boxes = None
+        else:
+            combined_bounding_boxes = [
+                box
+                for chunk in all_chunks
+                if chunk.bounding_boxes is not None
+                for box in chunk.bounding_boxes
+            ]
+
+        if self.pages is None:
+            combined_pages = None
+        else:
+            combined_pages = [
+                page
+                for chunk in all_chunks
+                if chunk.pages is not None
+                for page in chunk.pages
+            ]
 
         return Chunk(
             # TODO: can we better handle IDs when merging chunks?
             id=self.id,
-            text=text_separator.join([self.text, other.text]),
+            text=text_separator.join(all_texts),
             chunk_type=self.chunk_type,
             bounding_boxes=combined_bounding_boxes,
             pages=combined_pages,

--- a/src/test/test_chunk_processors.py
+++ b/src/test/test_chunk_processors.py
@@ -1,3 +1,5 @@
+import pytest
+
 from cpr_sdk.parser_models import BlockType
 
 from src.models import Chunk
@@ -6,6 +8,7 @@ from src.chunk_processors import (
     RemoveRepeatedAdjacentChunks,
     AddHeadings,
     RemoveRegexPattern,
+    RemoveFalseCheckboxes,
 )
 
 
@@ -276,9 +279,16 @@ def test_add_headings():
     assert results[6].heading.id == results[5].id  # type: ignore
 
 
-def test_remove_selection_patterns():
+@pytest.mark.parametrize(
+    "processor",
+    [
+        RemoveRegexPattern(pattern=r"\s?:(?:un)?selected:\s?", replace_with=" "),
+        RemoveFalseCheckboxes(),
+    ],
+)
+def test_remove_selection_patterns(processor):
     """Test removal of :selected: and :unselected: patterns from chunks."""
-    cleaner = RemoveRegexPattern(pattern=r"\s?:(?:un)?selected:\s?", replace_with=" ")
+
     chunks = [
         Chunk(
             text=":selected:",
@@ -324,7 +334,7 @@ def test_remove_selection_patterns():
         ),
     ]
 
-    result = cleaner(chunks)
+    result = processor(chunks)
 
     assert len(result) == 3
 

--- a/src/test/test_chunk_processors.py
+++ b/src/test/test_chunk_processors.py
@@ -348,7 +348,7 @@ def test_remove_selection_patterns(processor):
 def test_combine_successive_same_type_chunks():
     """Test combining successive chunks of the same type."""
     processor = CombineSuccessiveSameTypeChunks(
-        chunk_types=[BlockType.TEXT, BlockType.PAGE_HEADER],
+        chunk_types_to_combine=[BlockType.TEXT, BlockType.PAGE_HEADER],
         text_separator=" ",
     )
     chunks = [

--- a/src/test/test_chunk_processors.py
+++ b/src/test/test_chunk_processors.py
@@ -5,6 +5,7 @@ from src.chunk_processors import (
     RemoveShortTableCells,
     RemoveRepeatedAdjacentChunks,
     AddHeadings,
+    RemoveRegexPattern,
 )
 
 
@@ -273,3 +274,60 @@ def test_add_headings():
 
     # Text under the second section heading
     assert results[6].heading.id == results[5].id  # type: ignore
+
+
+def test_remove_selection_patterns():
+    """Test removal of :selected: and :unselected: patterns from chunks."""
+    cleaner = RemoveRegexPattern(pattern=r"\s?:(?:un)?selected:\s?", replace_with=" ")
+    chunks = [
+        Chunk(
+            text=":selected:",
+            chunk_type=BlockType.TEXT,
+            bounding_boxes=None,
+            pages=None,
+            id="1",
+        ),
+        Chunk(
+            text="Some :selected: text",
+            chunk_type=BlockType.TEXT,
+            bounding_boxes=None,
+            pages=None,
+            id="2",
+        ),
+        Chunk(
+            text="Multiple :selected: and :unselected: patterns",
+            chunk_type=BlockType.TEXT,
+            bounding_boxes=None,
+            pages=None,
+            id="3",
+        ),
+        Chunk(
+            text=":unselected:",
+            chunk_type=BlockType.TEXT,
+            bounding_boxes=None,
+            pages=None,
+            id="4",
+        ),
+        Chunk(
+            text=":unselected: :selected:",
+            chunk_type=BlockType.TEXT,
+            bounding_boxes=None,
+            pages=None,
+            id="4",
+        ),
+        Chunk(
+            text="Normal text",
+            chunk_type=BlockType.TEXT,
+            bounding_boxes=None,
+            pages=None,
+            id="5",
+        ),
+    ]
+
+    result = cleaner(chunks)
+
+    assert len(result) == 3
+
+    assert result[0].text == "Some text"
+    assert result[1].text == "Multiple and patterns"
+    assert result[2].text == "Normal text"

--- a/src/test/test_chunk_processors.py
+++ b/src/test/test_chunk_processors.py
@@ -9,6 +9,7 @@ from src.chunk_processors import (
     AddHeadings,
     RemoveRegexPattern,
     RemoveFalseCheckboxes,
+    CombineSuccessiveSameTypeChunks,
 )
 
 
@@ -341,3 +342,66 @@ def test_remove_selection_patterns(processor):
     assert result[0].text == "Some text"
     assert result[1].text == "Multiple and patterns"
     assert result[2].text == "Normal text"
+
+
+def test_combine_successive_same_type_chunks():
+    """Test combining successive chunks of the same type."""
+    processor = CombineSuccessiveSameTypeChunks(
+        chunk_types=[BlockType.TEXT, BlockType.PAGE_HEADER]
+    )
+    chunks = [
+        Chunk(
+            text="First text",
+            chunk_type=BlockType.TEXT,
+            bounding_boxes=None,
+            pages=None,
+            id="1",
+        ),
+        Chunk(
+            text="Second text",
+            chunk_type=BlockType.TEXT,
+            bounding_boxes=None,
+            pages=None,
+            id="2",
+        ),
+        Chunk(
+            text="Header 1",
+            chunk_type=BlockType.PAGE_HEADER,
+            bounding_boxes=None,
+            pages=None,
+            id="3",
+        ),
+        Chunk(
+            text="Header 2",
+            chunk_type=BlockType.PAGE_HEADER,
+            bounding_boxes=None,
+            pages=None,
+            id="4",
+        ),
+        Chunk(
+            text="Title",
+            chunk_type=BlockType.TITLE,
+            bounding_boxes=None,
+            pages=None,
+            id="5",
+        ),
+        Chunk(
+            text="Third text",
+            chunk_type=BlockType.TEXT,
+            bounding_boxes=None,
+            pages=None,
+            id="6",
+        ),
+    ]
+
+    result = processor(chunks)
+
+    assert len(result) == 4
+    assert result[0].text == "First text Second text"
+    assert result[0].chunk_type == BlockType.TEXT
+    assert result[1].text == "Header 1 Header 2"
+    assert result[1].chunk_type == BlockType.PAGE_HEADER
+    assert result[2].text == "Title"
+    assert result[2].chunk_type == BlockType.TITLE
+    assert result[3].text == "Third text"
+    assert result[3].chunk_type == BlockType.TEXT

--- a/src/test/test_models.py
+++ b/src/test/test_models.py
@@ -29,6 +29,43 @@ def test_merge_with_bounding_boxes_and_pages():
     assert merged.bounding_boxes == [[(0, 0), (1, 1)], [(2, 2), (3, 3)]]
 
 
+def test_merge_successive() -> None:
+    """Test successively merging chunks."""
+    chunk1 = Chunk(
+        id="1",
+        text="Hello",
+        chunk_type=BlockType.TEXT,
+        bounding_boxes=[[(0, 0), (1, 1)]],
+        pages=[1],
+    )
+    chunk2 = Chunk(
+        id="2",
+        text="World",
+        chunk_type=BlockType.TEXT,
+        bounding_boxes=[[(2, 2), (3, 3)]],
+        pages=[2],
+    )
+    chunk3 = Chunk(
+        id="3",
+        text="!",
+        chunk_type=BlockType.TEXT,
+        bounding_boxes=[[(4, 4), (5, 5)]],
+        pages=[3],
+    )
+
+    merged = chunk1.merge(chunk2).merge(chunk3, text_separator="")
+
+    assert merged.id == "1"
+    assert merged.text == "Hello World!"
+    assert merged.chunk_type == BlockType.TEXT
+    assert merged.pages == [1, 2, 3]
+    assert merged.bounding_boxes == [
+        [(0, 0), (1, 1)],
+        [(2, 2), (3, 3)],
+        [(4, 4), (5, 5)],
+    ]
+
+
 def test_merge_incompatible_properties():
     """Test merging chunks with incompatible properties raises ValueError."""
     chunk1 = Chunk(

--- a/src/test/test_models.py
+++ b/src/test/test_models.py
@@ -1,0 +1,91 @@
+import pytest
+from src.models import Chunk
+from cpr_sdk.parser_models import BlockType
+
+
+def test_merge_with_bounding_boxes_and_pages():
+    """Test merging chunks with bounding boxes and pages."""
+    chunk1 = Chunk(
+        id="1",
+        text="Hello",
+        chunk_type=BlockType.TEXT,
+        bounding_boxes=[[(0, 0), (1, 1)]],
+        pages=[1],
+    )
+    chunk2 = Chunk(
+        id="2",
+        text="World",
+        chunk_type=BlockType.TEXT,
+        bounding_boxes=[[(2, 2), (3, 3)]],
+        pages=[2],
+    )
+
+    merged = chunk1.merge(chunk2)
+
+    assert merged.id == "1"
+    assert merged.text == "Hello World"
+    assert merged.chunk_type == BlockType.TEXT
+    assert merged.pages == [1, 2]
+    assert merged.bounding_boxes == [[(0, 0), (1, 1)], [(2, 2), (3, 3)]]
+
+
+def test_merge_incompatible_properties():
+    """Test merging chunks with incompatible properties raises ValueError."""
+    chunk1 = Chunk(
+        id="1",
+        text="Hello",
+        chunk_type=BlockType.TEXT,
+        bounding_boxes=[[(0, 0), (1, 1)]],
+        pages=[1],
+    )
+    chunk2 = Chunk(
+        id="2", text="World", chunk_type=BlockType.TEXT, bounding_boxes=None, pages=None
+    )
+
+    with pytest.raises(ValueError):
+        chunk1.merge(chunk2)
+
+
+def test_merge_with_optional_properties():
+    """Test merging chunks with optional properties results in those properties being None."""
+    chunk1 = Chunk(
+        id="1",
+        text="Hello",
+        chunk_type=BlockType.TEXT,
+        bounding_boxes=None,
+        pages=None,
+        tokens=["Hello"],
+        heading=Chunk(
+            id="h1",
+            text="Title",
+            chunk_type=BlockType.SECTION_HEADING,
+            bounding_boxes=None,
+            pages=None,
+        ),
+    )
+    chunk2 = Chunk(
+        id="2",
+        text="World",
+        chunk_type=BlockType.TEXT,
+        bounding_boxes=None,
+        pages=None,
+        tokens=None,
+        heading=None,
+    )
+
+    merged = chunk1.merge(chunk2)
+    assert merged.tokens is None
+    assert merged.heading is None
+
+
+def test_merge_custom_separator():
+    """Test merging chunks with a custom text separator."""
+    chunk1 = Chunk(
+        id="1", text="Hello", chunk_type=BlockType.TEXT, bounding_boxes=None, pages=None
+    )
+    chunk2 = Chunk(
+        id="2", text="World", chunk_type=BlockType.TEXT, bounding_boxes=None, pages=None
+    )
+
+    merged = chunk1.merge(chunk2, text_separator="\n")
+    assert merged.text == "Hello\nWorld"

--- a/src/test/test_models.py
+++ b/src/test/test_models.py
@@ -20,7 +20,7 @@ def test_merge_with_bounding_boxes_and_pages():
         pages=[2],
     )
 
-    merged = chunk1.merge(chunk2)
+    merged = chunk1.merge([chunk2])
 
     assert merged.id == "1"
     assert merged.text == "Hello World"
@@ -29,11 +29,11 @@ def test_merge_with_bounding_boxes_and_pages():
     assert merged.bounding_boxes == [[(0, 0), (1, 1)], [(2, 2), (3, 3)]]
 
 
-def test_merge_successive() -> None:
+def test_merge_multiple() -> None:
     """Test successively merging chunks."""
     chunk1 = Chunk(
         id="1",
-        text="Hello",
+        text="Hello ",
         chunk_type=BlockType.TEXT,
         bounding_boxes=[[(0, 0), (1, 1)]],
         pages=[1],
@@ -53,7 +53,7 @@ def test_merge_successive() -> None:
         pages=[3],
     )
 
-    merged = chunk1.merge(chunk2).merge(chunk3, text_separator="")
+    merged = chunk1.merge([chunk2, chunk3], text_separator="")
 
     assert merged.id == "1"
     assert merged.text == "Hello World!"
@@ -80,7 +80,7 @@ def test_merge_incompatible_properties():
     )
 
     with pytest.raises(ValueError):
-        chunk1.merge(chunk2)
+        chunk1.merge([chunk2])
 
 
 def test_merge_with_optional_properties():
@@ -110,7 +110,7 @@ def test_merge_with_optional_properties():
         heading=None,
     )
 
-    merged = chunk1.merge(chunk2)
+    merged = chunk1.merge([chunk2])
     assert merged.tokens is None
     assert merged.heading is None
 
@@ -124,5 +124,5 @@ def test_merge_custom_separator():
         id="2", text="World", chunk_type=BlockType.TEXT, bounding_boxes=None, pages=None
     )
 
-    merged = chunk1.merge(chunk2, text_separator="\n")
+    merged = chunk1.merge([chunk2], text_separator="\n")
     assert merged.text == "Hello\nWorld"


### PR DESCRIPTION
Implements three chunk processors:

- combine successive chunks of the same (chosen) types into one. *Note this one won’t be used for TEXT- see next steps below*
- combine `text` chunks that look like lists into `list` chunks. This has scope to be refined after testing with Anne next week, but I think this initial implementation will give us enough to perform that testing. The important thing here is that we have something really dumb that doesn't break up lists into multiple chunks (also being aware that we might revisit that assumption later, and e.g. set a max length of list elements to set as type `list` vs separate `text` sentences).
- remove `:selected:` and `:unselected:` occurrences

Also:

- sets minimum length of `TableCell` text blocks to 0 (after @AnneIsARealProgrammerNow gave me a convincing argument that people are likely to want to find things like "CO2" and "O2", and that the issue is with how we present tables to users)

Next steps:

- create the first chunker! this will be a sentence-splitter (which also handles sentences which go across chunks of type `text`) and a basic character count split.
- create a basic semantic chunker, so test against the baseline chunker