### PR TITLE
fix bug with heading in serializer

### DIFF
--- a/src/serializers.py
+++ b/src/serializers.py
@@ -38,7 +38,7 @@ class HeadingAwareSerializer(PipelineComponent):
 
         for chunk in new_chunks:
             chunk.serialized_text = (
-                self.template.format(text=chunk.text, heading=chunk.heading)
+                self.template.format(text=chunk.text, heading=chunk.heading.text)
                 if chunk.heading
                 else chunk.text
             )


### PR DESCRIPTION
the whole heading model was being used instead of just its text