### PR TITLE
warn if serialized text is longer than model context window

### DIFF
--- a/src/encoders.py
+++ b/src/encoders.py
@@ -143,4 +143,11 @@ class SBERTEncoder(BaseEncoder):
     @property
     def dimension(self) -> int:
         """Return the dimension of the embedding."""
-        return self.encoder.get_sentence_embedding_dimension()
+        dimension = self.encoder.get_sentence_embedding_dimension()
+
+        if dimension is None:
+            raise ValueError(
+                "Dimension is not known for the encoder. This is an issue with the sentence-transformers library."
+            )
+
+        return dimension

--- a/src/encoders.py
+++ b/src/encoders.py
@@ -43,12 +43,6 @@ class BaseEncoder(ABC):
         """Return the dimension of the embeddings produced by the encoder."""
         raise NotImplementedError
 
-    @property
-    @abstractmethod
-    def context_window_length(self) -> int:
-        """Return the context window length of the encoder."""
-        raise NotImplementedError
-
 
 class SBERTEncoder(BaseEncoder):
     """Encoder which uses the sentence-transformers library.


### PR DESCRIPTION
This will eventually be a nice usecase for structured logging and observability, so I've added a TODO in. 

Also adds better handling of unknown embedding dimension.